### PR TITLE
Add support for attributes with array values

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -16,9 +16,11 @@ const dom = (type, attributes, ...children) => {
 	}
 
 	const handleAttrObjects = obj =>
-		(typeof obj === 'object')
-			? mapObject(obj).map(({key, value}) => `${key}:${value}`).join(';')
-			: obj;
+		Array.isArray(obj)
+			? obj.join(' ')
+			: (typeof obj === 'object')
+				? mapObject(obj).map(({key, value}) => `${key}:${value}`).join(';')
+				: obj;
 
 	const attr = mapObject(attributes)
 		.map(({key, value}) => ` ${key}="${handleAttrObjects(value)}"`)

--- a/test/test.js
+++ b/test/test.js
@@ -65,6 +65,13 @@ describe('isomorphic-jsx', () => {
 			'<div style="color:red;border:1px solid black"></div>'
 		)
 	})
+	
+	it('attribute array', () => {
+		assert.equal(
+			<div class={['class1', 'class2', 'class3']} />,
+			'<div class="class1 class2 class3"></div>'
+		)
+	})
 
 	it('namespace', () => {
 		assert.equal(


### PR DESCRIPTION
If an array is passed, it will join the values together with a space, for compatibility with the `class` attribute. For example, `class={['class1', 'class2', 'class3']}` will now become `class="class1 class2 class3"`.